### PR TITLE
Extend more things

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request: {}
+
+jobs:
+  check:
+    # Run `cargo check` first to ensure that the pushed code at least compiles.
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, 1.40.0]
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust }}
+        profile: minimal
+    - name: Check
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: --all --all-targets --all-features
+    - name: rustfmt
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
+
+  cargo-hack:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+    - name: Install cargo-hack
+      run: |
+        curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
+    - name: cargo hack check
+      working-directory: ${{ matrix.subcrate }}
+      run: cargo hack check --each-feature --no-dev-deps --all
+
+  test-versions:
+    # Test against the stable, beta, and nightly Rust toolchains on ubuntu-latest.
+    needs: check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, beta, nightly, 1.40.0]
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust }}
+        profile: minimal
+    - name: Run tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --all --all-features
+
+  deny-check:
+    name: cargo-deny check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: EmbarkStudios/cargo-deny-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
-None.
+- Support extensions on bare functions types (things like `fn(i32) -> bool`).
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 ## Unreleased
 
 - Support extensions on bare functions types (things like `fn(i32) -> bool`).
+- Support extensions on trait objects (things like `dyn Send + Sync`).
 
 ### Breaking changes
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,47 @@
+targets = []
+
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "warn"
+notice = "warn"
+ignore = []
+
+[licenses]
+unlicensed = "deny"
+allow = [
+    "MIT",
+    "Apache-2.0",
+]
+deny = []
+copyleft = "warn"
+allow-osi-fsf-free = "neither"
+default = "deny"
+confidence-threshold = 0.8
+exceptions = []
+
+[licenses.private]
+ignore = false
+registries = []
+
+[bans]
+multiple-versions = "deny"
+wildcards = "allow"
+highlight = "all"
+allow = []
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[sources.allow-org]
+github = []
+gitlab = []
+bitbucket = []

--- a/tests/compile_fail/supertraits_are_actually_included.stderr
+++ b/tests/compile_fail/supertraits_are_actually_included.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `std::string::String: MyTrait` is not satisfied
+error[E0277]: the trait bound `String: MyTrait` is not satisfied
  --> $DIR/supertraits_are_actually_included.rs:6:6
   |
 5 | #[ext(supertraits = MyTrait)]
@@ -6,5 +6,5 @@ error[E0277]: the trait bound `std::string::String: MyTrait` is not satisfied
 6 | impl String {
   |      ^^^^^^
   |      |
-  |      the trait `MyTrait` is not implemented for `std::string::String`
+  |      the trait `MyTrait` is not implemented for `String`
   |      required by a bound in this

--- a/tests/compile_pass/extension_on_complex_types.rs
+++ b/tests/compile_pass/extension_on_complex_types.rs
@@ -30,6 +30,15 @@ impl (i32, i64) {
     fn foo(self) {}
 }
 
+#[ext]
+impl fn(i32) -> bool {
+    fn foo(self) {}
+}
+
+fn bare_fn(_: i32) -> bool {
+    false
+}
+
 fn main() {
     "".foo();
 
@@ -41,4 +50,6 @@ fn main() {
     &[1, 2, 3].foo();
 
     (1i32, 1i64).foo();
+
+    (bare_fn as fn(i32) -> bool).foo();
 }

--- a/tests/compile_pass/extension_on_complex_types.rs
+++ b/tests/compile_pass/extension_on_complex_types.rs
@@ -39,6 +39,9 @@ fn bare_fn(_: i32) -> bool {
     false
 }
 
+#[ext]
+impl dyn Send + Sync + 'static {}
+
 fn main() {
     "".foo();
 


### PR DESCRIPTION
- Support extensions on bare functions types (things like `fn(i32) -> bool`).
- Support extensions on trait objects (things like `dyn Send + Sync`).