### PR TITLE
Add `#[ext_sized]` for adding `Sized` supertrait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 - Support setting visibility of the generated trait directly on the `impl`
   block. For example: `pub impl i32 { ... }`.
+- Add `#[ext_sized]` for adding `Sized` supertrait.
 
 ### Breaking changes
 

--- a/tests/compile_pass/sized.rs
+++ b/tests/compile_pass/sized.rs
@@ -1,0 +1,36 @@
+use extend::ext_sized;
+
+#[ext_sized(name = One)]
+impl i32 {
+    fn requires_sized(self) -> Option<Self> {
+        Some(self)
+    }
+}
+
+#[ext_sized(name = Two, supertraits = Default)]
+impl i32 {
+    fn with_another_supertrait(self) -> Option<Self> {
+        Some(self)
+    }
+}
+
+#[ext_sized(name = Three, supertraits = Default + Clone + Copy)]
+impl i32 {
+    fn multiple_supertraits(self) -> Option<Self> {
+        Some(self)
+    }
+}
+
+#[ext_sized(name = Four, supertraits = Sized)]
+impl i32 {
+    fn already_sized(self) -> Option<Self> {
+        Some(self)
+    }
+}
+
+fn main() {
+    1.requires_sized();
+    1.with_another_supertrait();
+    1.multiple_supertraits();
+    1.already_sized();
+}


### PR DESCRIPTION
This adds `#[ext_sized]` which is a convenience for `#[ext(supertraits =
Sized)]`.

Fixes https://github.com/davidpdrsn/extend/issues/16