### PR TITLE
Support setting visibility on the `impl` block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
-None.
+- Support setting visibility of the generated trait directly on the `impl`
+  block. For example: `pub impl i32 { ... }`.
 
 ### Breaking changes
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,6 +204,13 @@ pub fn ext(
     let mut config = parse_macro_input!(attr as Config);
 
     if let Some(vis) = item.vis {
+        if config.visibility != Visibility::Inherited {
+            abort!(
+                config.visibility.span(),
+                "Cannot set visibility on `#[ext]` and `impl` block"
+            );
+        }
+
         config.visibility = vis;
     }
 

--- a/tests/compile_fail/double_vis.rs
+++ b/tests/compile_fail/double_vis.rs
@@ -1,0 +1,14 @@
+mod a {
+    use extend::ext;
+
+    #[ext(pub(super))]
+    pub impl i32 {
+        fn foo() -> Foo {
+            Foo
+        }
+    }
+
+    pub struct Foo;
+}
+
+fn main() {}

--- a/tests/compile_fail/double_vis.stderr
+++ b/tests/compile_fail/double_vis.stderr
@@ -1,0 +1,5 @@
+error: Cannot set visibility on `#[ext]` and `impl` block
+ --> $DIR/double_vis.rs:4:11
+  |
+4 |     #[ext(pub(super))]
+  |           ^^^

--- a/tests/compile_pass/pub_impl.rs
+++ b/tests/compile_pass/pub_impl.rs
@@ -1,0 +1,15 @@
+mod a {
+    use extend::ext;
+
+    #[ext]
+    pub impl i32 {
+        fn foo() -> Foo { Foo }
+    }
+
+    pub struct Foo;
+}
+
+fn main() {
+    use a::i32Ext;
+    i32::foo();
+}


### PR DESCRIPTION
I noticed [`easy-ext`] did this and I think its pretty neat.

Makes this possible:

```rust
mod a {
    use extend::ext;

    #[ext]
    pub impl i32 {
        fn foo() -> Foo { Foo }
    }

    pub struct Foo;
}
```

[`easy-ext`]: https://github.com/taiki-e/easy-ext